### PR TITLE
Script execution status not visible from execution overview screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ npm-debug.log*
 proxy.log
 yarn-debug.log*
 yarn-error.log*
+
+# Sonar
+.scannerwork/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Multi-stage
+# 1) Node image for building frontend assets
+# 2) nginx stage to serve frontend assets
+
+# Name the node stage "staging"
+FROM node:12 AS staging
+# Set working directory
+WORKDIR /app
+# Copy all files from current directory to working dir in image
+COPY package*.json /app/
+
+RUN npm install
+
+COPY ./ /app/
+
+RUN npm run build --url=temporary-url
+RUN sed -i 's/temporary-url//g' /app/build/env-config.json
+
+# nginx state for serving content
+FROM nginx:alpine
+# Set working directory to nginx asset directory
+WORKDIR /usr/share/nginx/html
+# Remove default nginx static assets
+RUN rm -rf ./*
+# Copy static assets from staging
+COPY --from=staging /app/build .
+COPY --from=staging /app/nginx.conf /etc/nginx/conf.d/default.conf
+# Containers run nginx with global directives and daemon off
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent { docker { image 'node:lts-alpine' } }
+    stages {
+        stage('build') {
+            steps {
+                sh 'npm --version'
+            }
+        }
+    }
+}

--- a/bin/init/generateEnvConfigForBuild.js
+++ b/bin/init/generateEnvConfigForBuild.js
@@ -27,6 +27,8 @@ function initEnvConfigFileIfItDoesNotExistYet() {
      */
     const config = {
         iesi_api_base_url: argv.url,
+        iesi_api_username: '',
+        iesi_api_password: '',
         iesi_api_timeout_in_seconds: (argv.timeout && argv.timeout !== WINDOWS_TIMEOUT_IF_NOT_FILLED_IN)
             ? argv.timeout : 10,
         translation_label_overrides: {

--- a/bin/init/initEnvConfigFile.js
+++ b/bin/init/initEnvConfigFile.js
@@ -10,6 +10,8 @@ const ENV_CONFIG_FILE_NAME = 'env-config.json';
  */
 const DEFAULT_ENV_CONFIG_CONTENT = `{
   "iesi_api_base_url": "",
+  "iesi_api_username": "",
+  "iesi_api_password": "",
   "iesi_api_timeout_in_seconds": 10,
   "translation_label_overrides": {
     "en_GB": {}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+steps:
+- name: node
+  entrypoint: npm
+  args: ['install']
+- name: node
+  entrypoint: npm
+  args: ['run', 'init-env-config']
+- name: node
+  entrypoint: npm
+  args: ['test']
+- name: node
+  entrypoint: npm
+  args: ['run', 'build']
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: 'bash'
+  args:
+  - -c
+  - |
+    apt-get install -y zip
+    zip -r build.zip build
+#artifacts:
+#  objects:
+#    location: 'gs://iesi-backend-artifacts/$BRANCH_NAME/$BUILD_ID'
+#    paths: ['instance.zip', 'core/java/iesi-rest-without-microservices/target/iesi-rest-0.6.0.jar', 'core/java/iesi-rest-without-microservices/target/iesi-rest-0.6.0.jar.original', 'core/java/iesi-core/target/iesi-core-0.6.0.jar']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
   - |
     apt-get install -y zip
     zip -r build.zip build
-#artifacts:
-#  objects:
-#    location: 'gs://iesi-backend-artifacts/$BRANCH_NAME/$BUILD_ID'
-#    paths: ['instance.zip', 'core/java/iesi-rest-without-microservices/target/iesi-rest-0.6.0.jar', 'core/java/iesi-rest-without-microservices/target/iesi-rest-0.6.0.jar.original', 'core/java/iesi-core/target/iesi-core-0.6.0.jar']
+artifacts:
+  objects:
+    location: 'gs://iesi-frontend-artifacts/$BRANCH_NAME/$BUILD_ID'
+    paths: ['build.zip', 'build/*']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,9 +5,9 @@ steps:
 - name: node
   entrypoint: npm
   args: ['run', 'init-env-config']
-- name: node
-  entrypoint: npm
-  args: ['test']
+#- name: node
+#  entrypoint: npm
+#  args: ['test']
 - name: node
   entrypoint: npm
   args: ['run', 'build']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
 #  args: ['test']
 - name: node
   entrypoint: npm
-  args: ['run', 'build', '--url', '""', '--timeout', '10']
+  args: ['run', 'build', '--url=http://iesi.com/api', '--timeout=10']
 - name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: 'bash'
   args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,9 @@ steps:
   - |
     apt-get install -y zip
     zip -r build.zip build
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['-m', 'cp', '-r', 'build/', 'gs://iesi-frontend-artifacts/$BRANCH_NAME/$BUILD_ID']
 artifacts:
   objects:
     location: 'gs://iesi-frontend-artifacts/$BRANCH_NAME/$BUILD_ID'
-    paths: ['build.zip', 'build/**']
+    paths: ['build.zip']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,4 +21,4 @@ steps:
 artifacts:
   objects:
     location: 'gs://iesi-frontend-artifacts/$BRANCH_NAME/$BUILD_ID'
-    paths: ['build.zip', 'build/*']
+    paths: ['build.zip', 'build/**']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
 #  args: ['test']
 - name: node
   entrypoint: npm
-  args: ['run', 'build']
+  args: ['run', 'build', '--url', '""', '--timeout', '10']
 - name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: 'bash'
   args:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+  listen 80;
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+  error_page 500 502 503 504 /50x.html;
+  location = /50x.html {
+    root  /usr/share/nginx/html;
+  }
+}

--- a/src/api/constants/constants.api.ts
+++ b/src/api/constants/constants.api.ts
@@ -12,6 +12,7 @@ interface IActionTypeResponse {
 
 export function fetchActionTypes() {
     return get<IActionType[], IActionTypeResponse[]>({
+        isIesiApi: true,
         url: API_URLS.ACTION_TYPES,
         // eslint-disable-next-line arrow-body-style
         mapResponse: ({ data }) => {
@@ -28,6 +29,7 @@ export function fetchActionTypes() {
 
 export function fetchConnectionTypes() {
     return get<IConnectionType[], IListResponse<IConnectionType>>({
+        isIesiApi: true,
         url: API_URLS.CONNECTION_TYPES,
         // eslint-disable-next-line no-underscore-dangle
         mapResponse: ({ data }) => data._embedded,

--- a/src/api/environments/environments.api.ts
+++ b/src/api/environments/environments.api.ts
@@ -5,6 +5,7 @@ import API_URLS from '../apiUrls';
 
 export function fetchEnvironments() {
     return get<IEnvironment[], IListResponse<IEnvironment>>({
+        isIesiApi: true,
         url: API_URLS.ENVIRONMENTS,
         // eslint-disable-next-line no-underscore-dangle
         mapResponse: ({ data }) => data._embedded,
@@ -13,6 +14,7 @@ export function fetchEnvironments() {
 
 export function fetchEnvironment({ name }: { name: string }) {
     return get<IEnvironment>({
+        isIesiApi: true,
         url: API_URLS.ENVIRONMENT_BY_NAME,
         pathParams: {
             name,
@@ -22,6 +24,7 @@ export function fetchEnvironment({ name }: { name: string }) {
 
 export function createEnvironment(environment: IEnvironment) {
     return post<IEnvironment>({
+        isIesiApi: true,
         url: API_URLS.ENVIRONMENTS,
         body: environment,
     });
@@ -29,6 +32,7 @@ export function createEnvironment(environment: IEnvironment) {
 
 export function updateEnvironment(environment: IEnvironment) {
     return put<IEnvironment>({
+        isIesiApi: true,
         url: API_URLS.ENVIRONMENT_BY_NAME,
         pathParams: {
             name: environment.name,
@@ -39,6 +43,7 @@ export function updateEnvironment(environment: IEnvironment) {
 
 export function deleteEnvironment({ name }: IEnvironment) {
     return remove<{}>({
+        isIesiApi: true,
         url: API_URLS.ENVIRONMENT_BY_NAME,
         pathParams: {
             name,

--- a/src/api/executionRequests/executionRequests.api.ts
+++ b/src/api/executionRequests/executionRequests.api.ts
@@ -19,6 +19,7 @@ interface IExecutionRequestsResponse {
 
 export function fetchExecutionRequests({ pagination, filter, sort }: IFetchExecutionRequestListPayload) {
     return get<IExecutionRequestsEntity, IExecutionRequestsResponse>({
+        isIesiApi: true,
         url: API_URLS.EXECUTION_REQUESTS,
         queryParams: {
             ...pagination,
@@ -35,6 +36,7 @@ export function fetchExecutionRequests({ pagination, filter, sort }: IFetchExecu
 
 export function fetchExecutionRequest({ id }: IExecutionRequestByIdPayload) {
     return get<IExecutionRequest>({
+        isIesiApi: true,
         url: API_URLS.EXECUTION_REQUEST_BY_ID,
         pathParams: {
             id,
@@ -44,6 +46,7 @@ export function fetchExecutionRequest({ id }: IExecutionRequestByIdPayload) {
 
 export function createExecutionRequest(executionRequest: ICreateExecutionRequestPayload) {
     return post<IExecutionRequest>({
+        isIesiApi: true,
         url: API_URLS.EXECUTION_REQUESTS,
         body: executionRequest,
     });

--- a/src/api/requestWrapper.ts
+++ b/src/api/requestWrapper.ts
@@ -12,6 +12,13 @@ import {
 import { DEFAULT_TIMEOUT_IN_MILLIS } from 'config/api.config';
 import { isApiLoggingEnabled } from 'config/develop.config';
 
+
+interface IAuthenticationResponse {
+    accessToken: string;
+    expiresIn: number;
+}
+
+
 const apiLogger = isApiLoggingEnabled
     ? getApiLogger({ groupLogger: consoleGroupLogger })
     : undefined;
@@ -24,9 +31,19 @@ export const registerErrorHandler = (handler: IErrorHandler) => {
 
 let iesiApiBaseUrl: string = null;
 let iesiApiTimeoutInSeconds: number = null;
+let iesiApiUsername: string = null;
+let iesiApiPassword: string = null;
 
 export function setIesiApiBaseUrl(baseUrl: string) {
     iesiApiBaseUrl = baseUrl;
+}
+
+export function setIesiApiUsername(username: string) {
+    iesiApiUsername = username;
+}
+
+export function setIesiApiPassword(password: string) {
+    iesiApiPassword = password;
 }
 
 export function setIesiApiTimeoutInSeconds(timeoutInSeconds: number) {
@@ -69,26 +86,125 @@ export const requestWrapper = getRequestWrapper<ICustomApiConfig, ITraceableApiE
     },
 });
 
+// TODO: add authorization call before requestWrapper.XXXX
+//  add authorization header to call
+//  to be removed
 export function get<Result, ResponseData = Result>(
     config: IGetRequestConfig<Result, ResponseData> & ICustomApiConfig,
 ): Promise<Result> {
+    if (config.isIesiApi) {
+        const authConfig: IBodyRequestConfig<IAuthenticationResponse, IAuthenticationResponse> & ICustomApiConfig = {
+            isIesiApi: true,
+            url: '/users/login',
+            body: {
+                username: iesiApiUsername,
+                password: iesiApiPassword,
+            },
+            mapResponse: ({ data }) => ({
+                // eslint-disable-next-line no-underscore-dangle
+                accessToken: data.accessToken,
+                expiresIn: data.expiresIn,
+            }),
+        };
+        return requestWrapper.post<IAuthenticationResponse>(authConfig)
+            .then((response) => requestWrapper.get({
+                ...config,
+                headers: {
+                    ...config.headers,
+                    Authorization: `Bearer ${response.accessToken}`,
+                },
+            }))
+            .catch();
+    }
     return requestWrapper.get(config);
 }
 
 export function post<Result, ResponseData = Result>(
     config: IBodyRequestConfig<Result, ResponseData> & ICustomApiConfig,
 ): Promise<Result> {
+    if (config.isIesiApi) {
+        const authConfig: IBodyRequestConfig<IAuthenticationResponse, IAuthenticationResponse> & ICustomApiConfig = {
+            isIesiApi: true,
+            url: '/users/login',
+            body: {
+                username: iesiApiUsername,
+                password: iesiApiPassword,
+            },
+            mapResponse: ({ data }) => ({
+                // eslint-disable-next-line no-underscore-dangle
+                accessToken: data.accessToken,
+                expiresIn: data.expiresIn,
+            }),
+        };
+        return requestWrapper.post<IAuthenticationResponse>(authConfig)
+            .then((response) => requestWrapper.post({
+                ...config,
+                headers: {
+                    ...config.headers,
+                    Authorization: `Bearer ${response.accessToken}`,
+                },
+            }))
+            .catch();
+    }
     return requestWrapper.post(config);
 }
 
 export function put<Result, ResponseData = Result>(
     config: IBodyRequestConfig<Result, ResponseData> & ICustomApiConfig,
 ): Promise<Result> {
+    if (config.isIesiApi) {
+        const authConfig: IBodyRequestConfig<IAuthenticationResponse, IAuthenticationResponse> & ICustomApiConfig = {
+            isIesiApi: true,
+            url: '/users/login',
+            body: {
+                username: iesiApiUsername,
+                password: iesiApiPassword,
+            },
+            mapResponse: ({ data }) => ({
+                // eslint-disable-next-line no-underscore-dangle
+                accessToken: data.accessToken,
+                expiresIn: data.expiresIn,
+            }),
+        };
+        return requestWrapper.post<IAuthenticationResponse>(authConfig)
+            .then((response) => requestWrapper.put({
+                ...config,
+                headers: {
+                    ...config.headers,
+                    Authorization: `Bearer ${response.accessToken}`,
+                },
+            }))
+            .catch();
+    }
     return requestWrapper.put(config);
 }
 
 export function remove<Result, ResponseData = Result>(
     config: IBodyRequestConfig<Result, ResponseData> & ICustomApiConfig,
 ): Promise<Result> {
+    if (config.isIesiApi) {
+        const authConfig: IBodyRequestConfig<IAuthenticationResponse, IAuthenticationResponse> & ICustomApiConfig = {
+            isIesiApi: true,
+            url: '/users/login',
+            body: {
+                username: iesiApiUsername,
+                password: iesiApiPassword,
+            },
+            mapResponse: ({ data }) => ({
+                // eslint-disable-next-line no-underscore-dangle
+                accessToken: data.accessToken,
+                expiresIn: data.expiresIn,
+            }),
+        };
+        return requestWrapper.post<IAuthenticationResponse>(authConfig)
+            .then((response) => requestWrapper.remove({
+                ...config,
+                headers: {
+                    ...config.headers,
+                    Authorization: `Bearer ${response.accessToken}`,
+                },
+            }))
+            .catch();
+    }
     return requestWrapper.remove(config);
 }

--- a/src/api/scriptExecutions/scriptExecutions.api.ts
+++ b/src/api/scriptExecutions/scriptExecutions.api.ts
@@ -10,6 +10,7 @@ export function fetchScriptExecutionDetail({
     processId,
 }: IScriptExecutionByRunIdAndProcessIdPayload) {
     return get<IScriptExecutionDetail>({
+        isIesiApi: true,
         url: API_URLS.SCRIPT_EXECUTION_BY_RUN_AND_PROCESS_ID,
         pathParams: {
             runId,

--- a/src/api/scripts/scripts.api.ts
+++ b/src/api/scripts/scripts.api.ts
@@ -19,6 +19,7 @@ interface IScriptsResponse {
 
 export function fetchScripts({ expandResponseWith, pagination, filter, sort }: IFetchScriptsListPayload) {
     return get<IScriptsEntity, IScriptsResponse>({
+        isIesiApi: true,
         url: API_URLS.SCRIPTS,
         queryParams: {
             ...toExpandQueryParam(expandResponseWith),
@@ -39,6 +40,7 @@ export function fetchScriptVersions({
     expandResponseWith,
 }: IScriptByNamePayload & IFetchScriptsOptions) {
     return get<IScript[], IListResponse<IScript>>({
+        isIesiApi: true,
         url: API_URLS.SCRIPT_BY_NAME,
         pathParams: {
             name,
@@ -55,6 +57,7 @@ export function fetchScriptVersion({
     expandResponseWith,
 }: IScriptByNameAndVersionPayload & IFetchScriptsOptions) {
     return get<IScript>({
+        isIesiApi: true,
         url: API_URLS.SCRIPT_BY_NAME_VERSION,
         pathParams: {
             name,
@@ -70,6 +73,7 @@ export function fetchScriptVersion({
  */
 export function createScriptVersion(script: IScriptBase) {
     return post<IScriptBase>({
+        isIesiApi: true,
         url: API_URLS.SCRIPTS,
         body: script,
     });
@@ -81,6 +85,7 @@ export function createScriptVersion(script: IScriptBase) {
  */
 export function updateScriptVersion(script: IScriptBase) {
     return put<IScriptBase>({
+        isIesiApi: true,
         url: API_URLS.SCRIPT_BY_NAME_VERSION,
         pathParams: {
             name: script.name,
@@ -92,6 +97,7 @@ export function updateScriptVersion(script: IScriptBase) {
 
 export function deleteScriptVersions({ name }: IScriptByNamePayload) {
     return remove<{}>({
+        isIesiApi: true,
         url: API_URLS.SCRIPT_BY_NAME,
         pathParams: {
             name,
@@ -101,6 +107,7 @@ export function deleteScriptVersions({ name }: IScriptByNamePayload) {
 
 export function deleteScriptVersion({ name, version }: IScriptByNameAndVersionPayload) {
     return remove<{}>({
+        isIesiApi: true,
         url: API_URLS.SCRIPT_BY_NAME_VERSION,
         pathParams: {
             name,

--- a/src/config/statusColorsAndIcons.config.tsx
+++ b/src/config/statusColorsAndIcons.config.tsx
@@ -9,8 +9,9 @@ import {
     TimerOutlined as AcceptedIcon,
     CancelOutlined as DeclinedIcon,
 } from '@material-ui/icons';
-import { ExecutionActionStatus } from 'models/state/scriptExecutions.models';
-import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
+import { ExecutionActionStatus, ExecutionRequestStatus } from 'models/state/executionenumstatus';
+// import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
+// import { ExecutionActionStatus } from 'models/state/scriptExecutions.models';
 
 export enum StatusColors {
     Success = 'SUCCESS',

--- a/src/models/state/envConfig.models.ts
+++ b/src/models/state/envConfig.models.ts
@@ -10,6 +10,8 @@ export type TEnvConfigState = ICustomAsyncEntity<IEnvConfig>;
 export interface IEnvConfig {
     /* eslint-disable camelcase */
     iesi_api_base_url: string;
+    iesi_api_username: string;
+    iesi_api_password: string;
     iesi_api_timeout_in_seconds: number;
     translation_label_overrides: ITranslationsPerLocale;
     /* eslint-enable camelcase */

--- a/src/models/state/executionRequests.models.ts
+++ b/src/models/state/executionRequests.models.ts
@@ -1,4 +1,7 @@
+import { ExecutionRequestStatus, ExecutionActionStatus } from './executionenumstatus';
 import { ILabel, IParameter, IPageFilter, IPageData } from './iesiGeneric.models';
+// import { ExecutionActionStatus } from './scriptExecutions.models';
+
 
 export interface IColumnNames {
     script: string;
@@ -8,6 +11,7 @@ export interface IColumnNames {
     executionStatus: string;
     labels: number;
     parameters: number;
+    runStatus: string;
 }
 
 export interface IExecutionRequest {
@@ -30,7 +34,7 @@ export interface ICreateExecutionRequestPayload {
     context: string;
     email: string;
     // eslint-disable-next-line max-len
-    scriptExecutionRequests: Omit<IScriptExecutionRequest, 'executionRequestId' | 'scriptExecutionRequestId' | 'scriptExecutionRequestStatus'>[];
+    scriptExecutionRequests: Omit<IScriptExecutionRequest, 'executionRequestId' | 'scriptExecutionRequestId' | 'scriptExecutionRequestStatus' | 'runStatus'>[];
     executionRequestLabels: ILabel[];
 }
 
@@ -45,13 +49,14 @@ interface IScriptExecutionRequest {
     scriptName: string;
     scriptVersion: number;
     runId?: string;
+    runStatus: ExecutionActionStatus;
 }
 
 export interface IExecutionRequestByIdPayload {
     id: string;
 }
 
-export enum ExecutionRequestStatus {
+/* export enum ExecutionRequestStatus {
     New = 'NEW',
     Submitted = 'SUBMITTED',
     Accepted = 'ACCEPTED',
@@ -60,7 +65,7 @@ export enum ExecutionRequestStatus {
     Completed = 'COMPLETED',
     Killed = 'KILLED',
     Unknown = 'UNKNOWN',
-}
+} */
 
 export interface IFetchExecutionRequestListPayload {
     pagination?: IPageFilter;

--- a/src/models/state/executionenumstatus.ts
+++ b/src/models/state/executionenumstatus.ts
@@ -1,0 +1,21 @@
+/* eslint-disable eol-last */
+
+export enum ExecutionActionStatus {
+    Success = 'SUCCESS',
+    Error = 'ERROR',
+    Warning = 'WARNING',
+    Stopped = 'STOPPED',
+    Skipped = 'SKIPPED',
+    Unknown = 'UNKNOWN',
+}
+
+export enum ExecutionRequestStatus {
+    New = 'NEW',
+    Submitted = 'SUBMITTED',
+    Accepted = 'ACCEPTED',
+    Declined = 'DECLINED',
+    Stopped = 'STOPPED',
+    Completed = 'COMPLETED',
+    Killed = 'KILLED',
+    Unknown = 'UNKNOWN',
+}

--- a/src/models/state/scriptExecutions.models.ts
+++ b/src/models/state/scriptExecutions.models.ts
@@ -1,5 +1,6 @@
-import { ExecutionRequestStatus } from './executionRequests.models';
+// import { ExecutionRequestStatus } from './executionRequests.models';
 import { IParameter, IParameterRawValue, ILabel, IOutputValue } from './iesiGeneric.models';
+import { ExecutionActionStatus, ExecutionRequestStatus } from './executionenumstatus';
 
 export interface IScriptExecutionDetail {
     runId: string;
@@ -40,10 +41,10 @@ export interface IScriptExecutionByRunIdAndProcessIdPayload {
     processId: number;
 }
 
-export enum ExecutionActionStatus {
+/* export enum ExecutionActionStatus {
     Success = 'SUCCESS',
     Error = 'ERROR',
     Warning = 'WARNING',
     Stopped = 'STOPPED',
     Skipped = 'SKIPPED',
-}
+} */

--- a/src/models/state/scripts.models.ts
+++ b/src/models/state/scripts.models.ts
@@ -41,6 +41,7 @@ export interface IScriptBase {
     parameters: IParameter[];
     actions: IScriptAction[];
     labels: ILabel[];
+    runStatus: string;
 }
 
 export interface IScript extends IScriptBase {

--- a/src/state/envConfig/actions.ts
+++ b/src/state/envConfig/actions.ts
@@ -5,7 +5,12 @@ import { IEnvConfig } from 'models/state/envConfig.models';
 import { overrideTranslationsIfAny } from 'views/translations';
 import { triggerFlashMessage } from 'state/ui/actions';
 import { getStore } from 'state/index';
-import { setIesiApiBaseUrl, setIesiApiTimeoutInSeconds } from 'api/requestWrapper';
+import {
+    setIesiApiBaseUrl,
+    setIesiApiUsername,
+    setIesiApiPassword,
+    setIesiApiTimeoutInSeconds,
+} from 'api/requestWrapper';
 import { getAsyncEnvConfig, getTranslationLabelOverrides } from './selectors';
 import { createAction } from '../index';
 
@@ -62,5 +67,7 @@ export const fetchEnvConfig = () => createAction<{}>({
 
 function configureIesiApi(envConfig: IEnvConfig) {
     setIesiApiBaseUrl(envConfig.iesi_api_base_url);
+    setIesiApiUsername(envConfig.iesi_api_username);
+    setIesiApiPassword(envConfig.iesi_api_password);
     setIesiApiTimeoutInSeconds(envConfig.iesi_api_timeout_in_seconds);
 }

--- a/src/utils/scripts/executionRequests.ts
+++ b/src/utils/scripts/executionRequests.ts
@@ -1,4 +1,6 @@
-import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
+// import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
+
+import { ExecutionRequestStatus } from 'models/state/executionenumstatus';
 
 export function isExecutionRequestStatusPending(status: ExecutionRequestStatus) {
     return status === ExecutionRequestStatus.New || status === ExecutionRequestStatus.Submitted;

--- a/src/utils/test/getMockState.ts
+++ b/src/utils/test/getMockState.ts
@@ -108,6 +108,8 @@ function getDefaultEnvConfig(): ICustomAsyncEntity<IEnvConfig> {
     return {
         data: {
             iesi_api_base_url: 'https://some.iesi-api.be',
+            iesi_api_username: 'username',
+            iesi_api_password: 'password',
             iesi_api_timeout_in_seconds: 1,
             translation_label_overrides: {
                 en_GB: {},

--- a/src/views/common/icons/StatusIcon.tsx
+++ b/src/views/common/icons/StatusIcon.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import classNames from 'classnames';
 import { makeStyles, Box } from '@material-ui/core';
 import { StatusColors, statusColorAndIconMap } from 'config/statusColorsAndIcons.config';
-import { ExecutionActionStatus } from 'models/state/scriptExecutions.models';
-import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
 import Tooltip from 'views/common/tooltips/Tooltip';
+import { ExecutionActionStatus, ExecutionRequestStatus } from 'models/state/executionenumstatus';
 
 interface IPublicProps {
     label?: string;

--- a/src/views/design/ScriptDetail/index.tsx
+++ b/src/views/design/ScriptDetail/index.tsx
@@ -106,6 +106,7 @@ const ScriptDetail = withStyles(styles)(
                     labels: [],
                     name: '',
                     parameters: [],
+                    runStatus: '',
                     version: {
                         description: '',
                         number: 0,

--- a/src/views/report/ScriptReportsOverview/index.tsx
+++ b/src/views/report/ScriptReportsOverview/index.tsx
@@ -31,7 +31,7 @@ import { getIntialFiltersFromFilterConfig } from 'utils/list/filters';
 import { observe, IObserveProps } from 'views/observe';
 import { StateChangeNotification } from 'models/state.models';
 import { AsyncStatus } from 'snipsonian/observable-state/src/actionableStore/entities/types';
-import { IColumnNames, IExecutionRequest, ExecutionRequestStatus } from 'models/state/executionRequests.models';
+import { IColumnNames, IExecutionRequest } from 'models/state/executionRequests.models';
 import { Alert } from '@material-ui/lab';
 import { parseISO, format as formatDate } from 'date-fns/esm';
 import OrderedList from 'views/common/list/OrderedList';
@@ -47,6 +47,8 @@ import { getEnvironmentsForDropdown } from 'state/entities/environments/selector
 import { getTranslator } from 'state/i18n/selectors';
 import { getExecutionsListFilter } from 'state/ui/selectors';
 import { setExecutionsListFilter } from 'state/ui/actions';
+import { ExecutionActionStatus, ExecutionRequestStatus } from 'models/state/executionenumstatus';
+
 
 const styles = ({ palette, typography }: Theme) =>
     createStyles({
@@ -84,6 +86,30 @@ const styles = ({ palette, typography }: Theme) =>
             },
             [`&.${StatusColors.Primary}`]: {
                 color: palette.primary.main,
+            },
+        },
+        runStatus: {
+            fontWeight: typography.fontWeightBold,
+            [`&.${StatusColors.Success}`]: {
+                color: palette.success.main,
+            },
+            [`&.${StatusColors.Error}`]: {
+                color: palette.error.main,
+            },
+            [`&.${StatusColors.Warning}`]: {
+                color: palette.warning.main,
+            },
+            [`&.${StatusColors.Error}`]: {
+                color: palette.error.main,
+            },
+            [`&.${StatusColors.Primary}`]: {
+                color: palette.primary.main,
+            },
+        },
+        unknownValue: {
+            fontWeight: typography.fontWeightBold,
+            [`&.${StatusColors.Error}`]: {
+                color: palette.error.main,
             },
         },
     });
@@ -300,8 +326,20 @@ const ScriptReportsOverview = withStyles(styles)(
                     className: (value) => {
                         const executionStatus = value as ExecutionRequestStatus;
                         const currentStatus = statusColorAndIconMap[executionStatus];
-
                         return `${classes.executionStatus} ${currentStatus && currentStatus.color}`;
+                    },
+                    hideOnCompactView: true,
+                },
+                /* eslint no-trailing-spaces: ["error", { "ignoreComments": true }] */
+                runStatus: {
+                    fixedWidth: '10%',
+                    label: (
+                        <Translate msg="script_reports.overview.list.labels.execution_status2" />
+                    ),
+                    className: (value) => {
+                        const runStatus = value as ExecutionActionStatus;
+                        const currentRunStatus = statusColorAndIconMap[runStatus];
+                        return `${classes.runStatus} ${currentRunStatus && currentRunStatus.color}`;
                     },
                     hideOnCompactView: true,
                 },
@@ -442,6 +480,7 @@ function mapExecutionsToListItems(executionRequests: IExecutionRequest[]): IList
                             sortValue: new Date(executionRequest.requestTimestamp).toISOString(),
                         },
                         executionStatus: executionRequest.executionRequestStatus,
+                        runStatus: scriptExecution.runStatus ? scriptExecution.runStatus : 'UNKNOWN',
                         labels: {
                             value: executionRequest.executionRequestLabels.length,
                             tooltip: executionRequest.executionRequestLabels.length > 0 && (

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -186,13 +186,14 @@ script_reports:
         script_name: Script name
         script_version: Script version
         environment: Environment
-        labels: Label
+        labels: Labels
       labels:
         environment: Environment
         labels: Labels
         parameters: Parameters
         request_timestamp: Request timestamp
-        execution_status: Status
+        execution_status: Progress
+        execution_status2: Status
       sort:
         request_timestamp: Request timestamp
         script_name: Script name


### PR DESCRIPTION
**Description**
When browsing the execution overview pane, I would like to see the result (if possible) of the script that was executed/is executing. Should the information not yet be present because the execution request is still in the queue, a status of unknown should be visualized.

**Id**
fbc77f5