### PR TITLE
Script execution status not visible from execution overview screen

### DIFF
--- a/src/config/statusColorsAndIcons.config.tsx
+++ b/src/config/statusColorsAndIcons.config.tsx
@@ -9,14 +9,15 @@ import {
     TimerOutlined as AcceptedIcon,
     CancelOutlined as DeclinedIcon,
 } from '@material-ui/icons';
-import { ExecutionActionStatus } from 'models/state/scriptExecutions.models';
-import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
+import { ExecutionActionStatus } from 'models/state/executionActionStatus.models';
+import { ExecutionRequestStatus } from 'models/state/executionRequestStatus.models';
 
 export enum StatusColors {
     Success = 'SUCCESS',
     SuccessDark = 'SUCCESS_DARK',
     Error = 'ERROR',
     Warning = 'WARNING',
+    Unknown = 'UNKNOWN',
     Primary = 'PRIMARY',
 }
 
@@ -74,7 +75,7 @@ export const statusColorAndIconMap: TStatusColorsAndIcons = {
     },
     UNKNOWN: {
         icon: <ErrorIcon />,
-        color: StatusColors.Error,
+        color: StatusColors.Primary,
     },
     RUNNING: {
         icon: <AcceptedIcon />,

--- a/src/models/state/executionActionStatus.models.ts
+++ b/src/models/state/executionActionStatus.models.ts
@@ -1,0 +1,9 @@
+
+export enum ExecutionActionStatus {
+    Success = 'SUCCESS',
+    Error = 'ERROR',
+    Warning = 'WARNING',
+    Stopped = 'STOPPED',
+    Skipped = 'SKIPPED',
+    Unknown = 'UNKNOWN',
+}

--- a/src/models/state/executionRequestStatus.models.ts
+++ b/src/models/state/executionRequestStatus.models.ts
@@ -1,0 +1,12 @@
+
+export enum ExecutionRequestStatus {
+    New = 'NEW',
+    Submitted = 'SUBMITTED',
+    Accepted = 'ACCEPTED',
+    Declined = 'DECLINED',
+    Stopped = 'STOPPED',
+    Completed = 'COMPLETED',
+    Killed = 'KILLED',
+    Unknown = 'UNKNOWN',
+    Running = 'RUNNING',
+}

--- a/src/models/state/executionRequests.models.ts
+++ b/src/models/state/executionRequests.models.ts
@@ -1,4 +1,6 @@
 import { ILabel, IParameter, IPageFilter, IPageData } from './iesiGeneric.models';
+import { ExecutionRequestStatus } from './executionRequestStatus.models';
+import { ExecutionActionStatus } from './executionActionStatus.models';
 
 export interface IColumnNames {
     script: string;
@@ -6,6 +8,7 @@ export interface IColumnNames {
     environment: string;
     requestTimestamp: string;
     executionStatus: string;
+    runStatus: string;
     labels: number;
     parameters: number;
 }
@@ -45,22 +48,11 @@ interface IScriptExecutionRequest {
     scriptName: string;
     scriptVersion: number;
     runId?: string;
+    runStatus?: ExecutionActionStatus;
 }
 
 export interface IExecutionRequestByIdPayload {
     id: string;
-}
-
-export enum ExecutionRequestStatus {
-    New = 'NEW',
-    Submitted = 'SUBMITTED',
-    Accepted = 'ACCEPTED',
-    Declined = 'DECLINED',
-    Stopped = 'STOPPED',
-    Completed = 'COMPLETED',
-    Killed = 'KILLED',
-    Unknown = 'UNKNOWN',
-    Running = 'RUNNING',
 }
 
 export interface IFetchExecutionRequestListPayload {

--- a/src/models/state/scriptExecutions.models.ts
+++ b/src/models/state/scriptExecutions.models.ts
@@ -1,4 +1,5 @@
-import { ExecutionRequestStatus } from './executionRequests.models';
+import { ExecutionRequestStatus } from './executionRequestStatus.models';
+import { ExecutionActionStatus } from './executionActionStatus.models';
 import { IParameter, IParameterRawValue, ILabel, IOutputValue } from './iesiGeneric.models';
 
 export interface IScriptExecutionDetail {
@@ -38,12 +39,4 @@ export interface IScriptExecutionDetailAction {
 export interface IScriptExecutionByRunIdAndProcessIdPayload {
     runId: string;
     processId: number;
-}
-
-export enum ExecutionActionStatus {
-    Success = 'SUCCESS',
-    Error = 'ERROR',
-    Warning = 'WARNING',
-    Stopped = 'STOPPED',
-    Skipped = 'SKIPPED',
 }

--- a/src/utils/scripts/executionRequests.ts
+++ b/src/utils/scripts/executionRequests.ts
@@ -1,4 +1,4 @@
-import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
+import { ExecutionRequestStatus } from 'models/state/executionRequestStatus.models';
 
 export function isExecutionRequestStatusPending(status: ExecutionRequestStatus) {
     return status === ExecutionRequestStatus.New || status === ExecutionRequestStatus.Submitted;

--- a/src/views/common/icons/StatusIcon.tsx
+++ b/src/views/common/icons/StatusIcon.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import classNames from 'classnames';
 import { makeStyles, Box } from '@material-ui/core';
 import { StatusColors, statusColorAndIconMap } from 'config/statusColorsAndIcons.config';
-import { ExecutionActionStatus } from 'models/state/scriptExecutions.models';
-import { ExecutionRequestStatus } from 'models/state/executionRequests.models';
+import { ExecutionActionStatus } from 'models/state/executionActionStatus.models';
+import { ExecutionRequestStatus } from 'models/state/executionRequestStatus.models';
 import Tooltip from 'views/common/tooltips/Tooltip';
 
 interface IPublicProps {

--- a/src/views/report/ScriptReportsOverview/index.tsx
+++ b/src/views/report/ScriptReportsOverview/index.tsx
@@ -31,7 +31,9 @@ import { getIntialFiltersFromFilterConfig } from 'utils/list/filters';
 import { observe, IObserveProps } from 'views/observe';
 import { StateChangeNotification } from 'models/state.models';
 import { AsyncStatus } from 'snipsonian/observable-state/src/actionableStore/entities/types';
-import { IColumnNames, IExecutionRequest, ExecutionRequestStatus } from 'models/state/executionRequests.models';
+import { IColumnNames, IExecutionRequest } from 'models/state/executionRequests.models';
+import { ExecutionRequestStatus } from 'models/state/executionRequestStatus.models';
+import { ExecutionActionStatus } from 'models/state/executionActionStatus.models';
 import { Alert } from '@material-ui/lab';
 import { parseISO, format as formatDate } from 'date-fns';
 import OrderedList from 'views/common/list/OrderedList';
@@ -75,6 +77,24 @@ const styles = ({ palette, typography }: Theme) =>
             },
             [`&.${StatusColors.SuccessDark}`]: {
                 color: palette.success.dark,
+            },
+            [`&.${StatusColors.Warning}`]: {
+                color: palette.warning.main,
+            },
+            [`&.${StatusColors.Error}`]: {
+                color: palette.error.main,
+            },
+            [`&.${StatusColors.Primary}`]: {
+                color: palette.primary.main,
+            },
+        },
+        runStatus: {
+            fontWeight: typography.fontWeightBold,
+            [`&.${StatusColors.Success}`]: {
+                color: palette.success.main,
+            },
+            [`&.${StatusColors.Error}`]: {
+                color: palette.error.main,
             },
             [`&.${StatusColors.Warning}`]: {
                 color: palette.warning.main,
@@ -276,13 +296,13 @@ const ScriptReportsOverview = withStyles(styles)(
                 },
                 version: {
                     className: classes.scriptVersion,
-                    fixedWidth: '7%',
+                    fixedWidth: '5%',
                 },
                 environment: {
                     label: (
                         <Translate msg="script_reports.overview.list.labels.environment" />
                     ),
-                    fixedWidth: '20%',
+                    fixedWidth: '15%',
                 },
                 requestTimestamp: {
                     label: (
@@ -305,13 +325,26 @@ const ScriptReportsOverview = withStyles(styles)(
                     },
                     hideOnCompactView: true,
                 },
+                runStatus: {
+                    fixedWidth: '10%',
+                    label: (
+                        <Translate msg="script_reports.overview.list.labels.run_status" />
+                    ),
+                    className: (value) => {
+                        const executionStatus = value as ExecutionRequestStatus;
+                        const currentStatus = statusColorAndIconMap[executionStatus];
+
+                        return `${classes.executionStatus} ${currentStatus && currentStatus.color}`;
+                    },
+                    hideOnCompactView: true,
+                },
                 labels: {
                     label: (
                         <Translate msg="script_reports.overview.list.labels.labels" />
                     ),
                     className: classes.executionLabels,
                     hideOnCompactView: true,
-                    fixedWidth: '8%',
+                    fixedWidth: '5%',
                 },
                 parameters: {
                     label: (
@@ -444,6 +477,8 @@ function mapExecutionsToListItems(
                             sortValue: new Date(executionRequest.requestTimestamp).toISOString(),
                         },
                         executionStatus: executionRequest.executionRequestStatus,
+                        runStatus: scriptExecution.runStatus
+                            ? scriptExecution.runStatus : ExecutionActionStatus.Unknown,
                         labels: {
                             value: executionRequest.executionRequestLabels.length,
                             tooltip: executionRequest.executionRequestLabels.length > 0 && (

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -192,7 +192,8 @@ script_reports:
         labels: Labels
         parameters: Parameters
         request_timestamp: Request timestamp
-        execution_status: Status
+        execution_status: Progress
+        run_status: Status
       sort:
         request_timestamp: Request timestamp
         script_name: Script name


### PR DESCRIPTION
**Description**
When browsing the execution overview pane, I would like to see the result (if possible) of the script that was executed/is executing. Should the information not yet be present because the execution request is still in the queue, a status of unknown should be visualized.

**Id**
fbc77f4