### PR TITLE
Add security group to information details in script overview screen

### DIFF
--- a/src/models/state/scripts.models.ts
+++ b/src/models/state/scripts.models.ts
@@ -13,6 +13,7 @@ export interface IFetchScriptsListPayload extends IFetchScriptsOptions {
 
 export interface IColumnNames {
     name: string;
+    securityGroupName: string;
     version: string;
     description: string;
     labels: number;
@@ -37,6 +38,7 @@ export interface IScriptsEntity {
 export interface IScriptBase {
     name: string;
     description: string;
+    securityGroupName: string;
     version: IScriptVersion;
     parameters: IParameter[];
     actions: IScriptAction[];

--- a/src/views/design/ScriptDetail/index.tsx
+++ b/src/views/design/ScriptDetail/index.tsx
@@ -106,6 +106,7 @@ const ScriptDetail = withStyles(styles)(
                     description: '',
                     labels: [],
                     name: '',
+                    securityGroupName: '',
                     parameters: [],
                     version: {
                         description: '',

--- a/src/views/design/ScriptsOverview/index.tsx
+++ b/src/views/design/ScriptsOverview/index.tsx
@@ -288,7 +288,7 @@ const ScriptsOverview = withStyles(styles)(
                 description: {
                     className: classes.scriptDescription,
                     noWrap: true,
-                    fixedWidth: '50%',
+                    fixedWidth: '40%',
                 },
                 labels: {
                     label: (

--- a/src/views/design/ScriptsOverview/index.tsx
+++ b/src/views/design/ScriptsOverview/index.tsx
@@ -277,10 +277,6 @@ const ScriptsOverview = withStyles(styles)(
                     className: classes.scriptName,
                     fixedWidth: '35%',
                 },
-                securityGroupName: {
-                    className: classes.scriptSecurityGroupName,
-                    fixedWidth: '10%',
-                },
                 version: {
                     className: classes.scriptVersion,
                     fixedWidth: '5%',
@@ -289,6 +285,10 @@ const ScriptsOverview = withStyles(styles)(
                     className: classes.scriptDescription,
                     noWrap: true,
                     fixedWidth: '40%',
+                },
+                securityGroupName: {
+                    className: classes.scriptSecurityGroupName,
+                    fixedWidth: '10%',
                 },
                 labels: {
                     label: (

--- a/src/views/design/ScriptsOverview/index.tsx
+++ b/src/views/design/ScriptsOverview/index.tsx
@@ -75,6 +75,10 @@ const styles = ({ palette, typography }: Theme) =>
         scriptLabels: {
             fontWeight: typography.fontWeightBold,
         },
+        scriptSecurityGroupName: {
+            fontWeight: typography.fontWeightBold,
+            fontSize: typography.pxToRem(12),
+        },
     });
 
 export const filterConfig: FilterConfig<Partial<IColumnNames>> = {
@@ -273,6 +277,10 @@ const ScriptsOverview = withStyles(styles)(
                     className: classes.scriptName,
                     fixedWidth: '35%',
                 },
+                securityGroupName: {
+                    className: classes.scriptSecurityGroupName,
+                    fixedWidth: '10%',
+                },
                 version: {
                     className: classes.scriptVersion,
                     fixedWidth: '5%',
@@ -468,6 +476,7 @@ function mapScriptsToListItems(scripts: IScript[]): IListItem<IColumnNames>[] {
         id: getUniqueIdFromScript(script),
         columns: {
             name: script.name,
+            securityGroupName: script.securityGroupName,
             description: script.description,
             version: (script.version.number).toString(),
             labels: {


### PR DESCRIPTION
**Description**
When browsing the script overview screen, the security group property of a script should be visible as a column in the list entry.


**04b0bf8**