### PR TITLE
IESI UI - "Action expected to fail" disabled for script creation/modification

### DIFF
--- a/src/models/state/scripts.models.ts
+++ b/src/models/state/scripts.models.ts
@@ -36,7 +36,6 @@ export interface IScriptsEntity {
 }
 
 export interface IScriptBase {
-    securityGroupName: string;
     name: string;
     description: string;
     securityGroupName: string;

--- a/src/views/design/ScriptDetail/EditAction/index.tsx
+++ b/src/views/design/ScriptDetail/EditAction/index.tsx
@@ -255,7 +255,7 @@ function EditAction({
                                 setErrorExpectedChecked(!errorExpectedChecked);
                             }}
                             disabled={!isCreateScriptRoute
-                                || !checkAuthority(SECURITY_PRIVILEGES.S_SCRIPTS_WRITE, securityGroupName)}
+                                && !checkAuthority(SECURITY_PRIVILEGES.S_SCRIPTS_WRITE, securityGroupName)}
                         />
                     </Box>
 

--- a/src/views/design/ScriptDetail/EditAction/index.tsx
+++ b/src/views/design/ScriptDetail/EditAction/index.tsx
@@ -254,8 +254,8 @@ function EditAction({
                             onChange={() => {
                                 setErrorExpectedChecked(!errorExpectedChecked);
                             }}
-                            disabled={!isCreateScriptRoute
-                                && !checkAuthority(SECURITY_PRIVILEGES.S_SCRIPTS_WRITE, securityGroupName)}
+                            disabled={!(isCreateScriptRoute
+                                || checkAuthority(SECURITY_PRIVILEGES.S_SCRIPTS_WRITE, securityGroupName))}
                         />
                     </Box>
 


### PR DESCRIPTION
Issue:
Checkbox to indicate "action expected to fail" is disabled in the IESI UI

- Expected: able to indicate an expected failing action
- Actual: not able flag the expected failing action

Context:
- Script creation - Adding an action
- Script modification - Modifying an action

**f84e7ef**