### PR TITLE
Refactor execution audit information

### DIFF
--- a/src/views/report/ScriptReportDetail/index.tsx
+++ b/src/views/report/ScriptReportDetail/index.tsx
@@ -254,6 +254,12 @@ function ExecutionDetail({ state }: IObserveProps) {
         const executionListItems: IDescriptionListItem[] = [
             ...(scriptExecutionData && asyncExecutionRequest.status === AsyncStatus.Success) ? [
                 {
+                    label: translator('script_reports.detail.side.execution.requestor.label'),
+                    value: scriptExecutionData.username.length
+                        ? <Translate msg={scriptExecutionData.username} />
+                        : <Translate msg="script_reports.detail.side.execution.requestor.none" />,
+                },
+                {
                     label: translator('script_reports.detail.side.execution.script_name.label'),
                     value: scriptExecutionData.scriptName,
                 },
@@ -318,10 +324,6 @@ function ExecutionDetail({ state }: IObserveProps) {
                     value: scriptExecutionData.designLabels.length
                         ? <ShowLabels labels={scriptExecutionData.designLabels} />
                         : <Translate msg="script_reports.detail.side.execution.design_labels.none" />,
-                },
-                {
-                    label: translator('script_reports.detail.side.execution.username.label'),
-                    value: scriptExecutionData.username,
                 },
             ] : [],
         ];

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -282,9 +282,9 @@ script_reports:
         output:
           label: Output
           none: '-'
-        username:
-          label: Username
-          none: '-'
+        requestor:
+          label: Requestor
+          none: 'anonymous'
 
 doc:
   dialog:


### PR DESCRIPTION
adjust the following displayed information:
* the 'username' field in the details of a script execution needs to be renamed to 'requestor'
* the 'username' (requestor) field needs to be moved to the top of the Execution details
* the value of the 'username' (requestor) field needs to be set to 'anomynous' when no value is returned by the API