### PR TITLE
bug: missing translation for component details

### DIFF
--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -353,7 +353,7 @@ components:
       update_current_version: Update current version
       save_as_new_version: Save as new version
     side:
-      toggle_button: Components Details
+      toggle_button: Details
       component_type: Type
       component_description: Description
       component_name: Name

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -353,6 +353,7 @@ components:
       update_current_version: Update current version
       save_as_new_version: Save as new version
     side:
+      toggle_button: Components Details
       component_type: Type
       component_description: Description
       component_name: Name


### PR DESCRIPTION
add tranlation for the missing key for Components detail

![componenst_bug](https://user-images.githubusercontent.com/6872974/122216666-ecf35980-ceac-11eb-86d7-e10d4f83a24f.PNG)
