### PR TITLE
re-run script from execution overview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13517,34 +13517,25 @@
       }
     },
     "react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
+        "react-router": "5.2.1",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       },
       "dependencies": {
-        "react-router": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-          "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+        "@babel/runtime": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "requires": {
-            "@babel/runtime": "^7.1.2",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "mini-create-react-context": "^0.4.0",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
+            "regenerator-runtime": "^0.13.4"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4636,8 +4636,7 @@
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -6081,7 +6080,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6104,7 +6102,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
       "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
-      "dev": true,
       "requires": {
         "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
@@ -6114,7 +6111,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6123,7 +6119,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -6162,7 +6157,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "dev": true,
           "requires": {
             "find-up": "^2.1.0"
           }
@@ -6258,25 +6252,24 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
           "requires": {
             "p-try": "^1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "parse-json": {
           "version": "2.2.0",
@@ -6313,7 +6306,7 @@
             "path-type": "^2.0.0"
           }
         },
-        "p-locate": {
+        "read-pkg-up": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
@@ -13497,11 +13490,11 @@
       }
     },
     "react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
@@ -13511,6 +13504,16 @@
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-router-dom": {
@@ -13525,6 +13528,25 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "react-router": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+          "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "history": "^4.9.0",
+            "hoist-non-react-statics": "^3.1.0",
+            "loose-envify": "^1.3.1",
+            "mini-create-react-context": "^0.4.0",
+            "path-to-regexp": "^1.7.0",
+            "prop-types": "^15.6.2",
+            "react-is": "^16.6.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0"
+          }
+        }
       }
     },
     "react-scripts": {
@@ -13550,6 +13572,7 @@
         "eslint-config-react-app": "^5.2.1",
         "eslint-loader": "3.0.3",
         "eslint-plugin-flowtype": "4.6.0",
+        "eslint-plugin-import": "2.20.1",
         "eslint-plugin-jsx-a11y": "6.2.3",
         "eslint-plugin-react": "7.19.0",
         "eslint-plugin-react-hooks": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-beautiful-dnd": "13.0.0",
     "react-dom": "^16.13.1",
     "react-router": "^5.2.1",
-    "react-router-dom": "^5.1.2",
+    "react-router-dom": "^5.3.0",
     "react-scripts": "3.4.1",
     "stylelint-webpack-plugin": "^1.2.3",
     "typescript": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -36,18 +36,19 @@
     "flat": "^5.0.0",
     "history": "^4.10.1",
     "immer": "^6.0.3",
+    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
     "notistack": "0.9.9",
     "ramda": "0.27.0",
     "react": "^16.13.1",
     "react-beautiful-dnd": "13.0.0",
     "react-dom": "^16.13.1",
+    "react-router": "^5.2.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "stylelint-webpack-plugin": "^1.2.3",
     "typescript": "3.8.3",
-    "use-debounce": "3.4.2",
-    "jsonwebtoken": "^8.5.1"
+    "use-debounce": "3.4.2"
   },
   "devDependencies": {
     "@kunstmaan/eslint-typescript-config": "^2.0.1",

--- a/src/views/design/ScriptsOverview/index.tsx
+++ b/src/views/design/ScriptsOverview/index.tsx
@@ -261,11 +261,16 @@ const ScriptsOverview = withStyles(styles)(
                         onConfirm={this.onDeleteScript}
                         showLoader={deleteStatus === AsyncStatus.Busy}
                     />
-                    <ExecuteScriptDialog
-                        scriptUniqueId={scriptIdToExecute}
-                        open={!!scriptIdToExecute}
-                        onClose={this.onCloseExecuteDialog}
-                    />
+                    {
+                        scriptIdToExecute && (
+                            <ExecuteScriptDialog
+                                scriptUniqueId={scriptIdToExecute}
+                                open={!!scriptIdToExecute}
+                                onClose={this.onCloseExecuteDialog}
+                            />
+                        )
+                    }
+
                 </>
             );
         }

--- a/src/views/design/ScriptsOverview/index.tsx
+++ b/src/views/design/ScriptsOverview/index.tsx
@@ -27,7 +27,7 @@ import {
     IListItem,
     SortOrder,
 } from 'models/list.models';
-import { IScript, IExpandScriptsResponseWith, IColumnNames } from 'models/state/scripts.models';
+import { IScript, IExpandScriptsResponseWith, IColumnNames, IScriptBase } from 'models/state/scripts.models';
 import ContentWithSlideoutPanel from 'views/common/layout/ContentWithSlideoutPanel';
 import GenericFilter from 'views/common/list/GenericFilter';
 import { getIntialFiltersFromFilterConfig } from 'utils/list/filters';
@@ -114,8 +114,7 @@ const sortActions: SortActions<Partial<IColumnNames>> = {
 
 interface IScriptState {
     scriptIdToDelete: string;
-    scriptIdToExecute: string;
-    loadDocDialogOpen: boolean;
+    selectedScript: IScriptBase;
 }
 
 const defaultSortedColumn: ISortedColumn<IColumnNames> = {
@@ -133,8 +132,7 @@ const ScriptsOverview = withStyles(styles)(
 
             this.state = {
                 scriptIdToDelete: null,
-                scriptIdToExecute: null,
-                loadDocDialogOpen: false,
+                selectedScript: null,
             };
 
             this.renderPanel = this.renderPanel.bind(this);
@@ -145,7 +143,7 @@ const ScriptsOverview = withStyles(styles)(
             this.clearScriptToDelete = this.clearScriptToDelete.bind(this);
             this.setScriptToDelete = this.setScriptToDelete.bind(this);
             this.onCloseExecuteDialog = this.onCloseExecuteDialog.bind(this);
-            this.setScriptToExecute = this.setScriptToExecute.bind(this);
+            this.setExecuteScriptDialogOpen = this.setExecuteScriptDialogOpen.bind(this);
 
             this.onDeleteScript = this.onDeleteScript.bind(this);
             // eslint-disable-next-line max-len
@@ -153,9 +151,6 @@ const ScriptsOverview = withStyles(styles)(
 
             this.fetchScriptsWithFilterAndPagination = this.fetchScriptsWithFilterAndPagination.bind(this);
             this.combineFiltersFromUrlAndCurrentFilters = this.combineFiltersFromUrlAndCurrentFilters.bind(this);
-
-            this.onLoadDocDialogOpen = this.onLoadDocDialogOpen.bind(this);
-            this.onLoadDocDialogClose = this.onLoadDocDialogClose.bind(this);
         }
 
         public componentDidMount() {
@@ -185,7 +180,7 @@ const ScriptsOverview = withStyles(styles)(
 
         public render() {
             const { classes, state } = this.props;
-            const { scriptIdToDelete, scriptIdToExecute } = this.state;
+            const { scriptIdToDelete, selectedScript } = this.state;
             const filterFromState = getScriptsListFilter(state);
 
             const scripts = getAsyncScripts(this.props.state);
@@ -262,11 +257,11 @@ const ScriptsOverview = withStyles(styles)(
                         showLoader={deleteStatus === AsyncStatus.Busy}
                     />
                     {
-                        scriptIdToExecute && (
+                        selectedScript && (
                             <ExecuteScriptDialog
-                                scriptUniqueId={scriptIdToExecute}
-                                open={!!scriptIdToExecute}
                                 onClose={this.onCloseExecuteDialog}
+                                scriptName={selectedScript.name}
+                                scriptVersion={selectedScript.version.number}
                             />
                         )
                     }
@@ -358,7 +353,7 @@ const ScriptsOverview = withStyles(styles)(
                                     {
                                         icon: <PlayArrowRounded />,
                                         label: translator('scripts.overview.list.actions.execute'),
-                                        onClick: this.setScriptToExecute,
+                                        onClick: this.setExecuteScriptDialogOpen,
                                         hideAction: (item: IListItem<IColumnNames>) =>
                                             !checkAuthority(
                                                 SECURITY_PRIVILEGES.S_EXECUTION_REQUEST_WRITE,
@@ -578,21 +573,16 @@ const ScriptsOverview = withStyles(styles)(
             this.setState({ scriptIdToDelete: id as string });
         }
 
+        private setExecuteScriptDialogOpen(id: ReactText) {
+            const scripts = getAsyncScripts(this.props.state);
+            const selectedScript = scripts.find((item) =>
+                getUniqueIdFromScript(item) === id);
+            this.setState({ selectedScript });
+        }
+
         private onCloseExecuteDialog() {
             triggerResetAsyncExecutionRequest({ operation: AsyncOperation.create });
-            this.setState({ scriptIdToExecute: null });
-        }
-
-        private setScriptToExecute(id: ReactText) {
-            this.setState({ scriptIdToExecute: id as string });
-        }
-
-        private onLoadDocDialogOpen() {
-            this.setState((state) => ({ ...state, loadDocDialogOpen: true }));
-        }
-
-        private onLoadDocDialogClose() {
-            this.setState((state) => ({ ...state, loadDocDialogOpen: false }));
+            this.setState({ selectedScript: null });
         }
     },
 );

--- a/src/views/report/ScriptReportDetail/index.tsx
+++ b/src/views/report/ScriptReportDetail/index.tsx
@@ -4,7 +4,7 @@ import { format as formatDate, parseISO } from 'date-fns';
 import isSet from '@snipsonian/core/es/is/isSet';
 import isEmptyObject from '@snipsonian/core/es/object/isEmptyObject';
 import { Box, Button, makeStyles, Typography } from '@material-ui/core';
-import { ChevronLeftRounded, ChevronRight } from '@material-ui/icons';
+import { ChevronLeftRounded, ChevronRight, PlayArrow } from '@material-ui/icons';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import Translate from '@snipsonian/react/es/components/i18n/Translate';
 import useExecuteOnUnmount from 'utils/hooks/useExecuteOnUnmount';
@@ -46,7 +46,7 @@ const useStyles = makeStyles(({ palette, typography }) => ({
         display: 'none',
     },
     rerunButton: {
-        alignSelf: 'end',
+        marginleft: 'auto',
     },
     scriptName: {
         fontWeight: typography.fontWeightBold,
@@ -97,9 +97,9 @@ function ExecutionDetail({ state }: IObserveProps) {
     useEffect(() => {
         if (
             !runId
-                && asyncExecutionRequest.status === AsyncStatus.Success
-                && executionRequestDetail.scriptExecutionRequests.length > 0
-                && executionRequestDetail.scriptExecutionRequests[0].runId
+            && asyncExecutionRequest.status === AsyncStatus.Success
+            && executionRequestDetail.scriptExecutionRequests.length > 0
+            && executionRequestDetail.scriptExecutionRequests[0].runId
         ) {
             redirectTo({
                 routeKey: ROUTE_KEYS.R_REPORT_DETAIL,
@@ -109,26 +109,26 @@ function ExecutionDetail({ state }: IObserveProps) {
                 },
             });
         }
-        return () => {};
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        return () => { };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [asyncExecutionRequest]);
 
     useEffect(() => {
         if (
             asyncExecutionRequest.status === AsyncStatus.Success
-                && asyncScriptExecutionData.status !== AsyncStatus.Busy
-                && (!isSet(scriptExecutionData)
-                    || scriptExecutionData.runId !== runId
-                    || (processId && scriptExecutionData.processId !== parseInt(processId, 10)))
-                && runId
+            && asyncScriptExecutionData.status !== AsyncStatus.Busy
+            && (!isSet(scriptExecutionData)
+                || scriptExecutionData.runId !== runId
+                || (processId && scriptExecutionData.processId !== parseInt(processId, 10)))
+            && runId
         ) {
             triggerFetchScriptExecutionDetail({
                 runId,
                 processId: processId ? parseInt(processId, 10) : -1,
             });
         }
-        return () => {};
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        return () => { };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [scriptExecutionData, runId, processId, asyncExecutionRequest]);
 
     useExecuteOnUnmount({
@@ -142,8 +142,7 @@ function ExecutionDetail({ state }: IObserveProps) {
     const isLoading = asyncExecutionRequest.status === AsyncStatus.Busy
         || asyncScriptExecutionData.status === AsyncStatus.Busy
         || (asyncExecutionRequest.status === AsyncStatus.Success
-                && asyncScriptExecutionData.status === AsyncStatus.Initial);
-
+            && asyncScriptExecutionData.status === AsyncStatus.Initial);
     return (
         <>
             <Loader show={isLoading} />
@@ -347,21 +346,23 @@ function ExecutionDetail({ state }: IObserveProps) {
 
         return (
             <Box mt={1} display="flex" flexDirection="column" flex="1 1 auto">
-                <Button
-                    variant="contained"
-                    color="secondary"
-                    size="small"
-                    endIcon={<ChevronRight />}
-                    onClick={() => setExecuteScriptDialogOpen(true)}
-                    className={classes.rerunButton}
-
-                >
-                    <Translate msg="script_reports.detail.side.execution.rerun" />
-                </Button>
                 <Box flex="0 1 auto" marginBottom={3}>
-                    <Typography variant="h4">
-                        <Translate msg="script_reports.detail.side.execution.title" />
-                    </Typography>
+                    <Box display="flex" flexDirection="row" justifyContent="space-between">
+                        <Typography variant="h4">
+                            <Translate msg="script_reports.detail.side.execution.title" />
+                        </Typography>
+                        <Button
+                            variant="contained"
+                            color="secondary"
+                            size="small"
+                            endIcon={<PlayArrow />}
+                            onClick={() => setExecuteScriptDialogOpen(true)}
+                            className={classes.rerunButton}
+
+                        >
+                            <Translate msg="script_reports.detail.side.execution.rerun" />
+                        </Button>
+                    </Box>
                     <DescriptionList items={executionListItems} noLineAfterListItem />
                 </Box>
             </Box>

--- a/src/views/report/ScriptReportDetail/index.tsx
+++ b/src/views/report/ScriptReportDetail/index.tsx
@@ -149,8 +149,16 @@ function ExecutionDetail({ state }: IObserveProps) {
             {
                 scriptExecutionData && executeScriptDialogOpen && (
                     <ExecuteScriptDialog
-                        executionRequestUniqueId={executionRequestId}
-                        open={!!executeScriptDialogOpen}
+                        initialFormValues={{
+                            name: executionRequestDetail.name,
+                            description: executionRequestDetail.description,
+                            environment: scriptExecutionData.environment,
+                            parameters: scriptExecutionData.inputParameters,
+                            executionRequestLabels: scriptExecutionData.executionLabels,
+
+                        }}
+                        scriptName={scriptExecutionData.scriptName}
+                        scriptVersion={scriptExecutionData.scriptVersion}
                         onClose={onCloseExecuteDialog}
                     />
                 )

--- a/src/views/report/ScriptReportsOverview/index.tsx
+++ b/src/views/report/ScriptReportsOverview/index.tsx
@@ -11,7 +11,7 @@ import Translate from '@snipsonian/react/es/components/i18n/Translate';
 import AppTemplateContainer from 'views/appShell/AppTemplateContainer';
 import GenericList from 'views/common/list/GenericList';
 import GenericSort from 'views/common/list/GenericSort';
-import { Replay, WatchLater } from '@material-ui/icons';
+import { PlayArrow, WatchLater } from '@material-ui/icons';
 import { redirectTo, ROUTE_KEYS } from 'views/routes';
 import ReportIcon from 'views/common/icons/Report';
 import {
@@ -437,8 +437,8 @@ const ScriptReportsOverview = withStyles(styles)(
                                 );
                             },
                         }, {
-                            icon: <Replay />,
-                            label: translator('script_reports.overview.list.actions.report'),
+                            icon: <PlayArrow />,
+                            label: translator('script_reports.overview.list.actions.rerun'),
                             onClick: (id: number) => {
                                 this.setState({ executionRequestIdtoExecute: id.toString() });
                             },

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -114,7 +114,6 @@ scripts:
         view: View
         execute: Run script
         report: Reporting
-        rerun: Re-run
       filter:
         last_run_status: Last run status
         script_name: Script name
@@ -224,6 +223,7 @@ script_reports:
     list:
       actions:
         report: Reporting
+        rerun: Re-run
       fetch_error: Something went wrong while loading the script executions, please try again.
       filter:
         script_name: Script name

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -79,7 +79,7 @@ scripts:
       error: Something went wrong during the creation of your execution request.
       success:
         text: Execution request is created.
-        close_button: Back to overview
+        close_button: Back
       form:
         description: Description
         name: Name
@@ -114,6 +114,7 @@ scripts:
         view: View
         execute: Run script
         report: Reporting
+        rerun: Re-run
       filter:
         last_run_status: Last run status
         script_name: Script name
@@ -278,6 +279,7 @@ script_reports:
     side:
       toggle_button: Details
       execution:
+        rerun: Re-run script
         title: Execution data
         script_name:
           label: Script name


### PR DESCRIPTION
**Description**
In the execution overview screen a 're-run' action needs to be added for every execution. When the re-run icon (import ReplayIcon from '@material-ui/icons/Replay';) is clicked the user is provided with the 'execute script' popup.

All fields of the 'execute script' popup (name, environment, input parameters, execution labels...) are prefilled based on the original execution.