### PR TITLE
Apply security for components at UI manipulation level

### DIFF
--- a/src/models/state/components.model.ts
+++ b/src/models/state/components.model.ts
@@ -24,6 +24,7 @@ export interface IComponentEntity {
 
 export interface IComponent {
     type: string;
+    securityGroupName: string;
     name: string;
     description: string;
     version: IComponentVersion;
@@ -50,6 +51,7 @@ export interface IComponentAttribute {
 
 export interface IComponentColumnNames {
     name: string;
+    securityGroupName: string;
     description: string;
     version: string;
     endpoint: string;
@@ -62,4 +64,5 @@ export interface IComponentColumnNamesBase {
     description: string;
     version: string;
     type: string;
+    securityGroupName: string;
 }

--- a/src/views/design/ComponentDetail/index.tsx
+++ b/src/views/design/ComponentDetail/index.tsx
@@ -210,16 +210,16 @@ const ComponentDetail = withStyles(styles)(
                                 checkAuthority(
                                     state,
                                     SECURITY_PRIVILEGES.S_COMPONENTS_WRITE,
-                                    newComponentDetail.securityGroupName
+                                    newComponentDetail.securityGroupName,
                                 )
                                     ? (
                                         <Translate msg="components.detail.save_component_dialog.text" />
                                     ) : (
                                         <Translate
-                                          msg="components.detail.save_component_dialog.text_securityGroup"
-                                          placeholders={{
-                                            securityGroup: newComponentDetail.securityGroupName
-                                          }}
+                                            msg="components.detail.save_component_dialog.text_securityGroup"
+                                            placeholders={{
+                                                securityGroup: newComponentDetail.securityGroupName,
+                                            }}
                                         />
                                     )
                             }

--- a/src/views/design/ComponentDetail/index.tsx
+++ b/src/views/design/ComponentDetail/index.tsx
@@ -206,7 +206,23 @@ const ComponentDetail = withStyles(styles)(
                         onClose={() => this.setState({ isSaveDialogOpen: false })}
                     >
                         <Typography>
-                            <Translate msg="components.detail.save_component_dialog.text" />
+                            {
+                                checkAuthority(
+                                    state,
+                                    SECURITY_PRIVILEGES.S_COMPONENTS_WRITE,
+                                    newComponentDetail.securityGroupName
+                                )
+                                    ? (
+                                        <Translate msg="components.detail.save_component_dialog.text" />
+                                    ) : (
+                                        <Translate
+                                          msg="components.detail.save_component_dialog.text_securityGroup"
+                                          placeholders={{
+                                            securityGroup: newComponentDetail.securityGroupName
+                                          }}
+                                        />
+                                    )
+                            }
                         </Typography>
                         <Box display="flex" alignItems="center" justifyContent="space-between" marginTop={2}>
                             <Box paddingRight={1}>

--- a/src/views/design/ComponentsOverview/index.tsx
+++ b/src/views/design/ComponentsOverview/index.tsx
@@ -18,10 +18,10 @@ import {
     SortOrder,
     SortType,
 } from 'models/list.models';
-import { checkAuthorityGeneral } from 'state/auth/selectors';
+import { checkAuthority, checkAuthorityGeneral } from 'state/auth/selectors';
 import { SECURITY_PRIVILEGES } from 'models/state/auth.models';
 import ContentWithSlideoutPanel from 'views/common/layout/ContentWithSlideoutPanel';
-import { IComponent, IComponentColumnNamesBase } from 'models/state/components.model';
+import { IComponent, IComponentColumnNames, IComponentColumnNamesBase } from 'models/state/components.model';
 import GenericList from 'views/common/list/GenericList';
 import { getTranslator } from 'state/i18n/selectors';
 import { setComponentsListFilter } from 'state/ui/actions';
@@ -59,6 +59,10 @@ const styles = ({ palette, typography }: Theme) =>
             fontWeight: typography.fontWeightBold,
         },
         componentDescription: {
+            fontWeight: typography.fontWeightBold,
+            fontSize: typography.pxToRem(12),
+        },
+        securityGroupName: {
             fontWeight: typography.fontWeightBold,
             fontSize: typography.pxToRem(12),
         },
@@ -262,8 +266,12 @@ const ComponentsOverview = withStyles(styles)(
                 description: {
                     label: <Translate msg="components.overview.list.labels.description" />,
                     className: classes.componentDescription,
-                    fixedWidth: '40%',
+                    fixedWidth: '30%',
                     noWrap: true,
+                },
+                securityGroupName: {
+                    className: classes.securityGroupName,
+                    fixedWidth: '10%',
                 },
             };
 
@@ -296,8 +304,12 @@ const ComponentsOverview = withStyles(styles)(
                                                     },
                                                 });
                                             },
-                                            hideAction: () => (
-                                                !checkAuthorityGeneral(state, SECURITY_PRIVILEGES.S_COMPONENTS_WRITE)
+                                            hideAction: (item: IListItem<IComponentColumnNames>) => (
+                                                !checkAuthority(
+                                                    state,
+                                                    SECURITY_PRIVILEGES.S_COMPONENTS_WRITE,
+                                                    item.columns.securityGroupName.toString(),
+                                                )
                                             ),
                                         }, {
                                             icon: <Visibility />,
@@ -314,15 +326,23 @@ const ComponentsOverview = withStyles(styles)(
                                                     },
                                                 });
                                             },
-                                            hideAction: () => (
-                                                checkAuthorityGeneral(state, SECURITY_PRIVILEGES.S_COMPONENTS_WRITE)
+                                            hideAction: (item: IListItem<IComponentColumnNames>) => (
+                                                checkAuthority(
+                                                    state,
+                                                    SECURITY_PRIVILEGES.S_COMPONENTS_WRITE,
+                                                    item.columns.securityGroupName.toString(),
+                                                )
                                             ),
                                         }, {
                                             icon: <Delete />,
                                             label: translator('components.overview.list.actions.delete'),
                                             onClick: this.setComponentToDelete,
-                                            hideAction: () => (
-                                                !checkAuthorityGeneral(state, SECURITY_PRIVILEGES.S_COMPONENTS_WRITE)
+                                            hideAction: (item: IListItem<IComponentColumnNames>) => (
+                                                !checkAuthority(
+                                                    state,
+                                                    SECURITY_PRIVILEGES.S_COMPONENTS_WRITE,
+                                                    item.columns.securityGroupName.toString(),
+                                                )
                                             ),
                                         },
                                     )}
@@ -463,6 +483,7 @@ function mapComponentsToListItems(components: IComponent[]): IListItem<IComponen
         id: getUniqueIdFromComponent(component),
         columns: {
             name: component.name,
+            securityGroupName: component.securityGroupName,
             description: component.version.description,
             version: component.version.number,
             type: component.type,

--- a/src/views/doc/OpenAPIOverview/index.tsx
+++ b/src/views/doc/OpenAPIOverview/index.tsx
@@ -324,6 +324,10 @@ const OpenAPIOverview = withStyles(styles)(
                     fixedWidth: '50%',
                     label: <Translate msg="doc.overview.component_columns.connection" />,
                 },
+                securityGroupName: {
+                    fixedWidth: '50%',
+                    label: <Translate msg="doc.overview.component_columns.security_group_name" />,
+                },
             };
 
             return (
@@ -399,6 +403,7 @@ function mapComponentsToListItems(components: IComponent[]): IListItem<IComponen
             endpoint: component.parameters.find((p) => p.name === 'endpoint'),
             type: component.parameters.find((p) => p.name === 'type'),
             connection: component.parameters.find((p) => p.name === 'connection'),
+            securityGroupName: component.securityGroupName,
         },
         isHandled: component.isHandled,
     }));

--- a/src/views/doc/common/EditComponentDialog/EditComponentDialog.tsx
+++ b/src/views/doc/common/EditComponentDialog/EditComponentDialog.tsx
@@ -19,6 +19,8 @@ import ExpandableParameter from 'views/design/ScriptDetail/EditAction/Expandable
 import TextInput from 'views/common/input/TextInput';
 import { SECURITY_PRIVILEGES } from 'models/state/auth.models';
 import { checkAuthorityGeneral } from 'state/auth/selectors';
+import { TRequiredFieldsState } from 'models/form.models';
+import requiredFieldsCheck from 'utils/form/requiredFieldsCheck';
 
 const useStyles = makeStyles(({ palette }: Theme) => ({
     content: {
@@ -54,31 +56,51 @@ function EditComponentDialog({ onClose, open, state, dispatch, component }: IPub
     const translator = getTranslator(state);
     const [parameters, setParameters] = useState(component.parameters);
     const [name, setName] = useState(component.name);
+    const [securityGroupName, setSecurityGroupName] = useState(component.securityGroupName);
     const [description, setDescription] = useState(component.description);
     const [version, setVersion] = useState(component.version.number);
     const [versionDescription, setVersionDescription] = useState(component.version.description);
+    const [requiredFieldsState, setRequiredFieldsState] = useState<TRequiredFieldsState<IComponent>>({
+        securityGroupName: {
+            showError: false,
+        },
+        name: {
+            showError: false,
+        },
+    });
     const componentTypes = getAsyncComponentTypes(state).data || [];
     const matchingComponentTypes = componentTypes.find((item) => item.type === 'http.request');
 
     if (!component) return <></>;
 
     const onValidateClick = () => {
-        dispatch(editComponent({
-            currentComponent: component,
-            newComponent: {
-                name,
-                type: component.type,
-                description,
-                version: {
-                    number: version,
-                    description: versionDescription,
-                },
-                parameters,
-                attributes: [],
-                isHandled: component.isHandled,
+        const newComponent: IComponent = {
+            name,
+            securityGroupName,
+            type: component.type,
+            description,
+            version: {
+                number: version,
+                description: versionDescription,
             },
-        }));
-        onClose();
+            parameters,
+            attributes: [],
+            isHandled: component.isHandled,
+        };
+        const { passed: passedRequired, requiredFieldsState: newRequiredFieldsState } = requiredFieldsCheck({
+            data: newComponent,
+            requiredFields: ['name', 'securityGroupName'],
+        });
+
+        if (passedRequired) {
+            dispatch(editComponent({
+                currentComponent: component,
+                newComponent,
+            }));
+            onClose();
+        } else {
+            setRequiredFieldsState(newRequiredFieldsState);
+        }
     };
 
     return (
@@ -103,9 +125,13 @@ function EditComponentDialog({ onClose, open, state, dispatch, component }: IPub
                                 variant="filled"
                                 defaultValue={name}
                                 label={translator('doc.dialog.edit.component.name')}
+                                error={requiredFieldsState.name.showError}
+                                // eslint-disable-next-line max-len
+                                helperText={requiredFieldsState.name.showError && 'Name is a required field'}
                                 fullWidth
                                 onBlur={(e) => setName(e.target.value)}
                                 className={classes.textField}
+                                required
                             />
                         </Paper>
                         <Paper className={classes.paperInput}>
@@ -128,6 +154,7 @@ function EditComponentDialog({ onClose, open, state, dispatch, component }: IPub
                                 fullWidth
                                 onBlur={(e) => setVersion(parseFloat(e.target.value))}
                                 className={classes.textField}
+                                required
                             />
                         </Paper>
                         <Paper className={classes.paperInput}>
@@ -138,6 +165,22 @@ function EditComponentDialog({ onClose, open, state, dispatch, component }: IPub
                                 fullWidth
                                 onBlur={(e) => setVersionDescription(e.target.value)}
                                 className={classes.textField}
+                            />
+                        </Paper>
+                    </Box>
+                    <Box marginBottom={2} width="100%">
+                        <Paper className={classes.paperInput}>
+                            <TextInput
+                                id="component-security-group"
+                                defaultValue={securityGroupName}
+                                variant="filled"
+                                label={translator('doc.dialog.edit.component.component_security')}
+                                error={requiredFieldsState.securityGroupName.showError}
+                                onBlur={(e) => setSecurityGroupName(e.target.value)}
+                                // eslint-disable-next-line max-len
+                                helperText={requiredFieldsState.securityGroupName.showError && 'Security group is a required field'}
+                                required
+                                fullWidth
                             />
                         </Paper>
                     </Box>

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -345,6 +345,7 @@ components:
         type: Type
         version: Version
         description: Description
+        security_group_name: Security Group Name
       fetch_error: Something went wrong while loading the components, please try again.
       actions:
         delete: Delete
@@ -370,6 +371,7 @@ components:
       component_description: Description
       component_name: Name
       component_version: Version
+      component_security: Security Group
     main:
       no_parameters:
         title: No parameters yet
@@ -506,6 +508,7 @@ doc:
         title: Edit the component values
         name: 'Name'
         description: 'Description'
+        component_security: 'Security group'
         versionNumber: 'Version number'
         versionDescription: 'Version description'
         endpoint: 'Endpoint'
@@ -537,6 +540,7 @@ doc:
       endpoint: 'Endpoint'
       type: 'Type'
       connection: 'Connection'
+      security_group_name: 'Security group name'
     action_buttons:
       save: 'Save to database, if existing, update it'
       edit: 'Edit the table cells'

--- a/src/views/translations/en_GB.yml
+++ b/src/views/translations/en_GB.yml
@@ -363,6 +363,7 @@ components:
     save_component_dialog:
       title: Save component
       text: Do you want to overwrite the current version or create a new version with the current changes?
+      text_securityGroup: Sorry, you don't have the permission to create that connection because your don't belong to the group {securityGroup}
       update_current_version: Update current version
       save_as_new_version: Save as new version
     side:


### PR DESCRIPTION
**ID**
1f3cc3e

Currently, IESI applies security to scripts/script execution/script execution request. But we want more security for other metadata such as connection/components/dataset/users/impersonation/etc.

While components can contain sensitive data such as auth credentials or token stored in http.request component, we must take care of who can consult the data. For example a component that belongs to the team B should not be displayed to the team A in the UI.

Currently, sensitive data can be viewed by everyone in IESI. For example, the component http.request still displays auth credentials or token in the UI for everyone. We want to apply security model to the connections to be visible only by a specific team in the UI. This way we can protect the data and keep trust.

![Security-Model_Brainstorming_page-0001](https://user-images.githubusercontent.com/91054695/137339156-a3021ccd-f34a-495d-acb7-9eca86891d7d.jpg)
![Security-Model_Brainstorming_page-0002](https://user-images.githubusercontent.com/91054695/137339164-8278edbd-ca7a-4a4c-b92b-6950229c97d8.jpg)

