### PR TITLE
Script Creation - Incorrect Message Pop-up

### DIFF
--- a/src/state/entities/scripts/triggers.ts
+++ b/src/state/entities/scripts/triggers.ts
@@ -53,7 +53,7 @@ export const triggerCreateScriptDetail = (payload: IScriptBase | IScriptImport) 
         notificationsToTrigger: [StateChangeNotification.DESIGN_SCRIPTS_DETAIL],
         onSuccess: ({ dispatch }) => {
             dispatch(triggerFlashMessage({
-                translationKey: 'flash_messages.script.import',
+                translationKey: 'flash_messages.script.create',
                 type: 'success',
             }));
         },


### PR DESCRIPTION
Screen: Script
Functionality: Creation of a **new** script
Description: When creating & saving a new script - the following messagebox appears: "The script has been successfully imported !" - while the script-import functionality was not used.

Expected:
- When creating a script from scratch - the following messagebox should appear: "The script has been successfully saved" or no messagebox should appear

Actual:
- When both creating a script from scratch or import json doc - the following messagebox appears: "The script has been successfully imported !"

Reasoning: conflicting information pop-up - script import was not used, but pop-up indicates it was.

Steps to reproduce:
- Start the script creation process
- Add a dummy action
- Save the [script[](url)](url)