### PR TITLE
Remove exit property from script execution request

### DIFF
--- a/src/models/state/executionRequests.models.ts
+++ b/src/models/state/executionRequests.models.ts
@@ -41,7 +41,6 @@ export interface ICreateExecutionRequestPayload {
 
 interface ICreateScriptExecutionRequestPayload {
     environment: string;
-    exit: boolean;
     impersonations: { name: string }[];
     parameters: IParameter[];
     scriptName: string;
@@ -52,7 +51,6 @@ interface IScriptExecutionRequest {
     scriptExecutionRequestId: string;
     executionRequestId: string;
     environment: string;
-    exit: boolean;
     impersonations: { name: string }[];
     parameters: IParameter[];
     scriptExecutionRequestStatus: ExecutionRequestStatus;

--- a/src/views/design/common/ExecuteScriptDialog/index.tsx
+++ b/src/views/design/common/ExecuteScriptDialog/index.tsx
@@ -419,7 +419,6 @@ function ExecuteScriptDialog({
                     scriptName,
                     scriptVersion,
                     environment: formValues.environment,
-                    exit: false,
                     impersonations: [], // TODO
                     parameters: formValues.parameters,
                 },


### PR DESCRIPTION
The 'exit' property for a script execution request is not used anymore.


**Id**
19f066c