### PR TITLE
rerun script description cannot be empty while optional field

### DIFF
--- a/src/views/design/common/ExecuteScriptDialog/index.tsx
+++ b/src/views/design/common/ExecuteScriptDialog/index.tsx
@@ -111,6 +111,8 @@ function ExecuteScriptDialog({
         return () => { };
     }, [environmentsAsyncInfo]);
 
+    console.log('FORM VALUES : ', formValues);
+
     return (
         <ClosableDialog
             onClose={onClose}
@@ -409,7 +411,7 @@ function ExecuteScriptDialog({
     function createExecutionRequest() {
         triggerCreateExecutionRequest({
             context: '', // May be ignored for now
-            description: formValues.description.trim(),
+            description: formValues.description ? formValues.description.trim() : '',
             email: null, // May be ignored for now
             executionRequestLabels: formValues.executionRequestLabels,
             name: formValues.name.trim(),


### PR DESCRIPTION
**id**
c4a3a05

**steps to reproduce**

- Go to previous executed script in reporting overview
- Click on “re-run” button
- Execute without providing value for “Description”
- error: not possible to execute

**Conclusion**
it’s required to provide a value for “Description” in the execution window while its not a mandatory field